### PR TITLE
Get credentials and api keys from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ email:password
 
 #### from environment
 
-Alternatively, set `OPENAI_ACCOUNTS="user1|pass1,user2|pass2,user3|pass3"` environment variable.`
+Alternatively, set `OPENAI_ACCOUNTS="user1:pass1;user2:pass2;user3:pass3"` environment variable.`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ After 2024-04-02, authentication is optional because there is no need for authen
 
 You have 2 ways to set credentials:
 
-#### Credentials from accounts.txt
+#### from file
 
 Access token and PUID(only for PLUS account) retrieval has been automated by [OpenAIAuth](https://github.com/xqdoo00o/OpenAIAuth/) with account email & password.
 
@@ -27,7 +27,7 @@ email:password
 ...
 ```
 
-#### Credentials from environment variables
+#### from environment
 
 Alternatively, set `OPENAI_ACCOUNTS="user1|pass1,user2|pass2,user3|pass3"` environment variable.`
 
@@ -51,6 +51,8 @@ Currently logged in account, using the GPT-4 model and most GPT-3.5 models, you 
 
 ### API Authentication (Optional)
 
+#### from file
+
 Custom API keys for this fake API, just like OpenAI api
 
 `api_keys.txt` - A list of API keys separated by new line
@@ -61,6 +63,10 @@ sk-123456
 88888888
 ...
 ```
+
+#### from environment
+
+Set the `API_KEYS="sk-123456,88888888"` environment variable.
 
 ## Getting set up
 ```  
@@ -75,7 +81,7 @@ go build
   - `SERVER_PORT` - Set to 8080 by default
   - `ENABLE_HISTORY` - Set to false by default
   - `OPENAI_ACCOUNTS` - The accounts you use for OpenAI
-
+  - `API_KEYS` - The API keys for clients to authenticate against your own API
 ### Files (Optional)
   - `proxies.txt` - A list of proxies separated by new line
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ email:password
 
 #### Credentials from environment variables
 
-Alternatively, set `OPENAI_EMAIL` and `OPENAI_PASSWORD` environment variables.
+Alternatively, set `OPENAI_ACCOUNTS="user1|pass1,user2|pass2,user3|pass3"` environment variable.`
 
 ---
 
@@ -74,8 +74,7 @@ go build
   - `SERVER_HOST` - Set to 127.0.0.1 by default
   - `SERVER_PORT` - Set to 8080 by default
   - `ENABLE_HISTORY` - Set to false by default
-  - `OPENAI_EMAIL` - The email you use for your account
-  - `OPENAI_PASSWORD` - The password you use for your account
+  - `OPENAI_ACCOUNTS` - The accounts you use for OpenAI
 
 ### Files (Optional)
   - `proxies.txt` - A list of proxies separated by new line

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ Create a fake API using ChatGPT's website
     
 ### Authentication
 
-#### After 2024-04-02, accouts.txt is optional because no need authentication for gpt-3.5.
+After 2024-04-02, authentication is optional because there is no need for authentication for gpt-3.5.
+
+You have 2 ways to set credentials:
+
+#### Credentials from accounts.txt
 
 Access token and PUID(only for PLUS account) retrieval has been automated by [OpenAIAuth](https://github.com/xqdoo00o/OpenAIAuth/) with account email & password.
 
@@ -23,11 +27,17 @@ email:password
 ...
 ```
 
-All authenticated access tokens and PUID will store in `access_tokens.json`
+#### Credentials from environment variables
 
-Auto renew access tokens and PUID after 1 day
+Alternatively, set `OPENAI_EMAIL` and `OPENAI_PASSWORD` environment variables.
 
-Caution! please use unblocked ip for authentication, first login to `https://chatgpt.com/` to check ip availability if you can.
+---
+
+All authenticated access tokens and PUID will be stored in `access_tokens.json` and auto-renewed after 24 hours.
+
+Caution! please use unblocked IP for authentication. First login to `https://chatgpt.com/` to check IP availability if you can.
+
+---
 
 ### HAR file pool
 
@@ -64,6 +74,8 @@ go build
   - `SERVER_HOST` - Set to 127.0.0.1 by default
   - `SERVER_PORT` - Set to 8080 by default
   - `ENABLE_HISTORY` - Set to false by default
+  - `OPENAI_EMAIL` - The email you use for your account
+  - `OPENAI_PASSWORD` - The password you use for your account
 
 ### Files (Optional)
   - `proxies.txt` - A list of proxies separated by new line

--- a/auth.go
+++ b/auth.go
@@ -84,16 +84,21 @@ func getSecret() (string, tokens.Secret) {
 	}
 }
 
-// Read accounts.txt and create a list of accounts
+// Read accounts and create a list of them
 func readAccounts() {
-	accounts = map[string]AccountInfo{}
+    accounts = map[string]AccountInfo{}
 
-	// Add environment variable check
-    if user := os.Getenv("OPENAI_EMAIL"); user != "" {
-        pass := os.Getenv("OPENAI_PASSWORD")
-        accounts[user] = AccountInfo{
-            Password: pass,
-            Times:    []int{1}, // Default usage time
+    // Read from environment variable
+    if envAccounts := os.Getenv("OPENAI_ACCOUNTS"); envAccounts != "" {
+        for _, account := range strings.Split(envAccounts, ",") {
+            parts := strings.Split(account, "|")
+            if len(parts) == 2 {
+                username, password := parts[0], parts[1]
+                accounts[username] = AccountInfo{
+                    Password: password,
+                    Times:    []int{1}, // Default usage time
+                }
+            }
         }
     }
 	

--- a/auth.go
+++ b/auth.go
@@ -87,6 +87,16 @@ func getSecret() (string, tokens.Secret) {
 // Read accounts.txt and create a list of accounts
 func readAccounts() {
 	accounts = map[string]AccountInfo{}
+
+	// Add environment variable check
+    if user := os.Getenv("OPENAI_EMAIL"); user != "" {
+        pass := os.Getenv("OPENAI_PASSWORD")
+        accounts[user] = AccountInfo{
+            Password: pass,
+            Times:    []int{1}, // Default usage time
+        }
+    }
+	
 	// Read accounts.txt and create a list of accounts
 	if _, err := os.Stat("accounts.txt"); err == nil {
 		// Each line is a proxy, put in proxies array

--- a/auth.go
+++ b/auth.go
@@ -91,7 +91,7 @@ func readAccounts() {
     // Read from environment variable
     if envAccounts := os.Getenv("OPENAI_ACCOUNTS"); envAccounts != "" {
         for _, account := range strings.Split(envAccounts, ",") {
-            parts := strings.Split(account, "|")
+            parts := strings.Split(account, ":")
             if len(parts) == 2 {
                 username, password := parts[0], parts[1]
                 accounts[username] = AccountInfo{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# This file is outdated. Use only for reference
+
 version: '3'
 
 services:


### PR DESCRIPTION
When installing through docker it is a pain having to setup the `accounts.txt` and `api_keys.txt` files. This PR adds support for passing the credentials and api keys as environment variables. The variables are:
- `OPENAI_ACCOUNTS`
- `API_KEYS`